### PR TITLE
Limited mark-mode support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,7 @@ Thanks to Udit Mukherjee (uditmukherjee457) for the contributions.
     e.g. Pressing Ctrl-S will launch search and pressing it again will go to the next item found
 
 *   (Ctrl-Y) Alt-Y      :   "yank-pop"
+
+**1.0.6   (1st May 2014)**
+
+*   Very basic mark-mode support.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "Emacs keybindings",
     "author": "Ahmad N. Raja",
     "homepage": "https://github.com/ahmadnazir/brackets-emacs",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "engines": { "brackets": ">=0.36.0" },
     "description": "A brackets extension for Emacs keybindings",
     "keywords": ["emacs"]


### PR DESCRIPTION
Here's a first pass at mark-mode support.  From the code it's clear you were already thinking about this, so you may have something better already.  I will not be offended if you go with what you've got already or need to rewrite most of this.

The key this is to:
- use codemirror's extending mode
- update the point/selection after changing the mode.
- use extendSelection for all cursor navigation so that codemirror has a chance to do the right/smart thing as the cursor moves around.

I make the ctrl-g binding and the kill logic call clearMark.  This results in things meeting a minimal level of sanity, but I'm sure there's a lot more to do.  I figured I'd send in this pull request before I go down a crazy road and end up with a massive patch that combines way too many things.  (Right now I would like some Alt-D support and to improve the forward/backward word navigation.)
